### PR TITLE
Refactor how json is rendered to allow nested hashes. Can now receive…

### DIFF
--- a/app/controllers/speech_results_controller.rb
+++ b/app/controllers/speech_results_controller.rb
@@ -7,7 +7,7 @@ class SpeechResultsController < ApplicationController
     user = User.find(params[:user_id])
 
     if authorized?(user)
-      render json: user.speech_results
+      render json: user.speech_results, include: ['speech_result']
     else
       render json: { errors: "Forbidden" }, status: 403
     end
@@ -35,7 +35,7 @@ class SpeechResultsController < ApplicationController
   def show
     speech_result = SpeechResult.find(params[:id])
     if authorized?(speech_result.user)
-        render json: speech_result
+        render json: speech_result, include: ['doc_emotion', 'doc_language_tone', 'doc_social_tone', 'taxonomies', 'keywords', 'keywords.keyword_emotion']
     else
       render json: { errors: "Forbidden" }, status: 403
     end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -1,4 +1,5 @@
 class KeywordSerializer < ActiveModel::Serializer
   attributes :text, :sentiment_type, :sentiment_score, :relevance, :count
+  belongs_to :speech_result
   has_one :keyword_emotion
 end


### PR DESCRIPTION
… keyword emotions. Add the include option to json rendering for user speech results so that the new code doesn't create a stack level too deep error and returns only the pertinent info.